### PR TITLE
Technical/notask fix get default rate

### DIFF
--- a/HappyTravel.CurrencyConverterApi/Data/DefaultCurrencyRate.cs
+++ b/HappyTravel.CurrencyConverterApi/Data/DefaultCurrencyRate.cs
@@ -1,13 +1,12 @@
 using System;
-using HappyTravel.Money.Enums;
 
 namespace HappyTravel.CurrencyConverterApi.Data
 {
     public class DefaultCurrencyRate
     {
         public decimal Rate { get; set; }
-        public Currencies Source { get; set; }
-        public Currencies Target { get; set; }
+        public string Source { get; set; } = null!;
+        public string Target { get; set; } = null!;
         public DateTime ValidFrom { get; set; }
     }
 }

--- a/HappyTravel.CurrencyConverterApi/Migrations/20210304154746_DefaultSourceTargetToText.Designer.cs
+++ b/HappyTravel.CurrencyConverterApi/Migrations/20210304154746_DefaultSourceTargetToText.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using HappyTravel.CurrencyConverterApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace HappyTravel.CurrencyConverterApi.Migrations
 {
     [DbContext(typeof(CurrencyConverterContext))]
-    partial class CurrencyConverterContextModelSnapshot : ModelSnapshot
+    [Migration("20210304154746_DefaultSourceTargetToText")]
+    partial class DefaultSourceTargetToText
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HappyTravel.CurrencyConverterApi/Migrations/20210304154746_DefaultSourceTargetToText.cs
+++ b/HappyTravel.CurrencyConverterApi/Migrations/20210304154746_DefaultSourceTargetToText.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HappyTravel.CurrencyConverterApi.Migrations
+{
+    public partial class DefaultSourceTargetToText : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Target",
+                table: "DefaultCurrencyRates",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Source",
+                table: "DefaultCurrencyRates",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Source\" = 'NotSpecified' WHERE \"Source\" = '0';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Source\" = 'USD' WHERE \"Source\" = '1';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Source\" = 'EUR' WHERE \"Source\" = '2';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Source\" = 'AED' WHERE \"Source\" = '3';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Source\" = 'SAR' WHERE \"Source\" = '4';");
+
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Target\" = 'NotSpecified' WHERE \"Target\" = '0';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Target\" = 'USD' WHERE \"Target\" = '1';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Target\" = 'EUR' WHERE \"Target\" = '2';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Target\" = 'AED' WHERE \"Target\" = '3';");
+            migrationBuilder.Sql("UPDATE \"DefaultCurrencyRates\" SET \"Target\" = 'SAR' WHERE \"Target\" = '4';");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Target",
+                table: "DefaultCurrencyRates",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Source",
+                table: "DefaultCurrencyRates",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/HappyTravel.CurrencyConverterApi/Services/RateService.cs
+++ b/HappyTravel.CurrencyConverterApi/Services/RateService.cs
@@ -206,11 +206,8 @@ namespace HappyTravel.CurrencyConverterApi.Services
                 !Enum.TryParse<Currencies>(target, out var targetValue))
                 return null;
             
-            //TODO Clarify the moment. Related with Get_should_not_use_outdated_default_rate test.
-            //var today = DateTime.Today;
             var storedDefaultRate = await _context.DefaultCurrencyRates
                 .Where(r => r.Source.Equals(sourceValue) && r.Target.Equals(targetValue))
-                //.Where(r => today <= r.ValidFrom)
                 .OrderByDescending(r => r.ValidFrom)
                 .Select(r => r.Rate)
                 .FirstOrDefaultAsync();

--- a/HappyTravel.CurrencyConverterApi/Services/RateService.cs
+++ b/HappyTravel.CurrencyConverterApi/Services/RateService.cs
@@ -201,13 +201,8 @@ namespace HappyTravel.CurrencyConverterApi.Services
             if (_cache.TryGetValue(cacheKey, out decimal result, GetTimeSpanToNextMinute()))
                 return result;
             
-            //TODO Need to change the type of Source and Target columns to text in DefaultCurrencyRates table 
-            if (!Enum.TryParse<Currencies>(source, out var sourceValue) ||
-                !Enum.TryParse<Currencies>(target, out var targetValue))
-                return null;
-            
             var storedDefaultRate = await _context.DefaultCurrencyRates
-                .Where(r => r.Source.Equals(sourceValue) && r.Target.Equals(targetValue))
+                .Where(r => r.Source.Equals(source) && r.Target.Equals(target))
                 .OrderByDescending(r => r.ValidFrom)
                 .Select(r => r.Rate)
                 .FirstOrDefaultAsync();

--- a/HappyTravel.CurrencyConverterApiTests/RatesServiceTests.cs
+++ b/HappyTravel.CurrencyConverterApiTests/RatesServiceTests.cs
@@ -357,7 +357,7 @@ namespace HappyTravel.CurrencyConverterApiTests
 
             var defaultCurrencyRatesMock = new List<DefaultCurrencyRate>
             {
-                new DefaultCurrencyRate {Rate = defaultRate, Source = Currencies.USD, Target = Currencies.AED, ValidFrom = DateTime.UtcNow}
+                new DefaultCurrencyRate {Rate = defaultRate, Source = "USD", Target = "AED", ValidFrom = DateTime.UtcNow}
             }.AsQueryable().BuildMockDbSet();
 
             var contextMock = new Mock<CurrencyConverterContext>();
@@ -393,8 +393,8 @@ namespace HappyTravel.CurrencyConverterApiTests
 
             var defaultCurrencyRatesMock = new List<DefaultCurrencyRate>
             {
-                new DefaultCurrencyRate {Rate = defaultRate + 0.1m, Source = Currencies.USD, Target = Currencies.AED, ValidFrom = DateTime.UtcNow.AddMinutes(-10)},
-                new DefaultCurrencyRate {Rate = defaultRate, Source = Currencies.USD, Target = Currencies.AED, ValidFrom = DateTime.UtcNow}
+                new DefaultCurrencyRate {Rate = defaultRate + 0.1m, Source = "USD", Target = "AED", ValidFrom = DateTime.UtcNow.AddMinutes(-10)},
+                new DefaultCurrencyRate {Rate = defaultRate, Source = "USD", Target = "AED", ValidFrom = DateTime.UtcNow}
             }.AsQueryable().BuildMockDbSet();
 
             var contextMock = new Mock<CurrencyConverterContext>();

--- a/HappyTravel.CurrencyConverterApiTests/RatesServiceTests.cs
+++ b/HappyTravel.CurrencyConverterApiTests/RatesServiceTests.cs
@@ -415,40 +415,6 @@ namespace HappyTravel.CurrencyConverterApiTests
             Assert.Equal(defaultRate, returnedValue);
         }
 
-        //TODO Clarify this test. Related with todo in RateService->GetDefaultRate
-/* 
-        [Fact]
-        public async Task Get_should_not_use_outdated_default_rate()
-        {
-            var defaultRate = 3.668m;
-            var httpRate = 3.672982m;
-
-            var currenciesList = new List<CurrencyRate>();
-            var currencyRatesMock = currenciesList.AsQueryable().BuildMockDbSet();
-
-            var defaultCurrencyRatesMock = new List<DefaultCurrencyRate>
-            {
-                new DefaultCurrencyRate {Rate = defaultRate, Source = Currencies.USD, Target = Currencies.AED, ValidFrom = DateTime.UtcNow.AddDays(-2)}
-            }.AsQueryable().BuildMockDbSet();
-
-            var contextMock = new Mock<CurrencyConverterContext>();
-            contextMock.Setup(m => m.CurrencyRates)
-                .Returns(currencyRatesMock.Object);
-            contextMock.Setup(m => m.DefaultCurrencyRates)
-                .Returns(defaultCurrencyRatesMock.Object);
-            currencyRatesMock.Setup(d => d.AddRange(It.IsAny<IEnumerable<CurrencyRate>>()))
-                .Callback<IEnumerable<CurrencyRate>>(currenciesList.AddRange);
-            contextMock.Setup(m => m.SaveChangesAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(0);
-
-            var service = new RateService(new NullLoggerFactory(), GetCache(), GetHttpClientFactory(), _options,
-                contextMock.Object);
-
-            var (isSuccess, _, returnedValue) = await service.Get(Currencies.USD, Currencies.AED);
-
-            Assert.Equal(httpRate, returnedValue);
-        }
-*/
 
         private static IDoubleFlow GetCache()
         {


### PR DESCRIPTION
Removed outdating from default rates.
Changed default rates source and target columns type to text.

Wasn't able to test, since migration will apply only after merge, but looks like should be fine.